### PR TITLE
Add regex filtering metrics

### DIFF
--- a/prometheus.yaml
+++ b/prometheus.yaml
@@ -9,31 +9,12 @@ scrape_configs:
     scrape_interval: 30s
     honor_labels: true
     metrics_path: '/federate'
+
     params:
       'match[]':
-        - '{__name__=~"(
-            up|
-            node_cpu_seconds_total|
-            container_memory_usage_bytes|
-            container_memory_cache|
-            node_memory_MemTotal_bytes|
-            node_memory_MemFree_bytes|
-            node_memory_Buffers_bytes|
-            node_memory_Cached_bytes|
-            container_fs_usage_bytes|
-            node_filesystem_size_bytes|
-            node_filesystem_free_bytes|
-            cadvisor_version_info|
-            container_last_seen|
-            dappmanager_auto_updates_system_packages|
-            dappmanager_auto_updates_user_packages|
-            dappmanager_eth_client_target_local|
-            dappmanager_eth_fallback_enabled|
-            dappmanager_ipfs_client_target_local|
-            dappmanager_staker_config|
-            container_cpu_usage_seconds_total
-          )"}'
-
+        - '{__name__=~"dappmanager.*"}'
+        - '{__name__=~"node_cpu_seconds_total|container_memory_usage_bytes|container_memory_cache|node_memory_MemTotal_bytes|node_memory_MemFree_bytes|node_memory_Buffers_bytes|node_memory_Cached_bytes|container_fs_usage_bytes|node_filesystem_size_bytes|node_filesystem_free_bytes|container_last_seen|cadvisor_version_info|container_cpu_usage_seconds_total"}'
+  
     static_configs:
       - targets:
           - "prometheus.dms.dappnode:9090"


### PR DESCRIPTION
closes #7 

Added regex that filters prometheus metrics scraped from the prometheus DMS service at "prometheus.dms.dappnode:9090". Only selected metrics are:
- dappmanager metrics
- all node-exporter metrics used by the monitor-service grafana dashboard.

This filtering lowers amount of metrics of my dappnode from ~17.000 metrics with my mail to ~1.200
![Screenshot from 2023-06-01 20-21-09](https://github.com/dappnode/ethical-metrics/assets/36164126/9d75f455-5d1d-4206-9f9a-1d6a2cb1fc98)


Also, scraping time of the metrics is significantly lower than other targets (1.2s)
![image](https://github.com/dappnode/ethical-metrics/assets/36164126/d955c73b-c807-441b-8e6b-afe5bd5e71d8)


**Metrics that pass the filter:**
_node_cpu_seconds_total
container_memory_usage_bytes
container_memory_cache
node_memory_MemTotal_bytes
node_memory_MemFree_bytes
node_memory_Buffers_bytes
node_memory_Cached_bytes
container_fs_usage_bytes
node_filesystem_size_bytes
node_filesystem_free_bytes
container_last_seen
cadvisor_version_info
container_last_seen
dappmanager_auto_updates_system_packages
dappmanager_auto_updates_user_packages
dappmanager_eth_client_target_local
dappmanager_eth_fallback_enabled
dappmanager_ipfs_client_target_local
dappmanager_staker_config
container_cpu_usage_seconds_total
node_cpu_seconds_total_