### PR TITLE
Call monitor-service to delete target when stopping or restarting the tor service

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,7 @@
 # Function to send HTTP DELETE request
 send_http_request() {
     INSTANCE=$(cat /var/lib/tor/hidden_service/hostname)
+    INSTANCE="$INSTANCE:9090"
     request_body='[
   {
     "instance": "'$INSTANCE'",
@@ -11,10 +12,15 @@ send_http_request() {
 ]'
     echo "Sending HTTP DELETE request for instance: $INSTANCE"
     echo "Request body: $request_body"
-    response=$(curl -X DELETE -H "Content-Type: application/json" -d "$request_body" -w "%{http_code}" "$REGISTER_URL")
+    response=$(curl -s -X DELETE -H "Content-Type: application/json" -d "$request_body" -w "%{http_code}" "$REGISTER_URL")
     echo "HTTP DELETE request sent."
+    echo "$response"
 
-    if [[ $response =~ ^2 ]]; then
+    # Extract the status code from the response
+    status_code=${response: -3}
+
+    # Check if status code from response starts with "2"
+    if [[ $status_code =~ ^2 ]]; then
         echo "Deleted instance successfully."
     else
         echo "Monitor service did not return 2xx code. Something went wrong"


### PR DESCRIPTION
This PR upgrades the `entrypoint.sh` script so that it handles SIGINT and SIGTERM signals (recieved when stopping or restarting the container). It also discovered a new possible bug of monitor service, more info below.

The new hander sends a DELETE http request to the monitor-service server (defined by the env URL variable REGISTER_URL) so that the server can delete notification policies and target files of the client instance. Once the request is done, it passes the SIGINT/SIGTERM signal to the tor process itself, so that it can stop gracefully.

Tested live: when stopping the container, server deletes target file and notification policy successfuly:
![image](https://github.com/dappnode/ethical-metrics/assets/36164126/d8b4ca39-dd24-444e-822d-f7d997656137)

When starting container again, the following message error appears on server side:
![image](https://github.com/dappnode/ethical-metrics/assets/36164126/d6f46275-c106-475d-83ea-47be4cca25fe)
The method "_UpdateContractPoint_" returns error when updating a contract point. It seems that the "UID" that identifies the contract point to update is empty in the server code (and it is used to access it), so grafana does not find the endpoint to update and returns 404  : https://github.com/dappnode/monitor-service/blob/a92024da7916b0d93a1abd986aab35fff97f78cb/register/src/instance/createInstance.go#L73-L81
Usage of UID of grafana service to update contract point:
![image](https://github.com/dappnode/ethical-metrics/assets/36164126/12300fa3-c720-476a-8432-f6f7a0e2e52b)

Possible solution: It could be fixed by setting UID to _instance_ when calling _UpdateContractPoint()_. 

Bug issue link: https://github.com/dappnode/monitor-service/issues/65

To register again successfuly, i had to do it with a new instance, so the "_UpdateContractPoint_" method was not called.

